### PR TITLE
fix: replace usages of grains.osfullname in package.repo.install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         always_run: true
         pass_filenames: false
   - repo: https://github.com/warpnet/salt-lint
-    rev: v0.8.0
+    rev: v0.9.2
     hooks:
       - id: salt-lint
         name: Check Salt files using salt-lint

--- a/rabbitmq/package/repo/install.sls
+++ b/rabbitmq/package/repo/install.sls
@@ -20,12 +20,12 @@ rabbitmq-package-repo-pkg-deps:
       - pkgrepo: rabbitmq-package-repo-erlang
       - pkgrepo: rabbitmq-package-repo-rabbitmq
 
-{%- set osfullname = grains['osfullname'] %}
+{%- set osname = grains['os'] %}
 {%- set oscodename = grains['oscodename'] %}
 
 rabbitmq-package-repo-erlang:
   pkgrepo.managed:
-    - name: deb {{ rabbitmq.pkg.repo.erlang.url }}/{{ osfullname|lower }} {{ oscodename }} main
+    - name: deb {{ rabbitmq.pkg.repo.erlang.url }}/{{ osname|lower }} {{ oscodename }} main
     - file: /etc/apt/sources.list.d/erlang.list
     - key_url: {{ rabbitmq.pkg.repo.erlang.key_url }}
     - require_in:
@@ -33,7 +33,7 @@ rabbitmq-package-repo-erlang:
 
 rabbitmq-package-repo-rabbitmq:
   pkgrepo.managed:
-    - name: deb {{ rabbitmq.pkg.repo.rabbitmq.url }}/{{ osfullname|lower }} {{ oscodename }} main
+    - name: deb {{ rabbitmq.pkg.repo.rabbitmq.url }}/{{ osname|lower }} {{ oscodename }} main
     - file: /etc/apt/sources.list.d/rabbitmq.list
     - key_url: {{ rabbitmq.pkg.repo.rabbitmq.key_url }}
     - require_in:


### PR DESCRIPTION
Replace the usage of `grains.osfullname` in `package.repo.install` because in newer Salt versions it may return an expanded value, breaking the package repositories.

Also fix a problem with an older salt-lint release.