### PR TITLE
fix: federation upstream set (ci error)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
         always_run: true
         pass_filenames: false
   - repo: https://github.com/warpnet/salt-lint
-    rev: v0.8.0
+    rev: v0.9.2
     hooks:
       - id: salt-lint
         name: Check Salt files using salt-lint

--- a/rabbitmq/config/parameters/install.sls
+++ b/rabbitmq/config/parameters/install.sls
@@ -18,7 +18,7 @@ rabbitmq-config-parameters-present-{{ name }}-{{ param }}:
                 {%- if p.component == 'federation-upstream' %}
             /usr/sbin/rabbitmqctl --node {{ name }} set_parameter --vhost={{ '/' if 'vhost' not in p else p.vhost }} {{ p.component }} '{{ param }}' '{{ p.definition|json }}'  # noqa 204
                 {%- else %}{# federation-upstream-set for now #}
-            /usr/sbin/rabbitmqctl --node {{ name }} set_parameter --vhost={{ '/' if 'vhost' not in p else p.vhost }} {{ p.component }} '{{ param }}' '[{{ p.definition|json }},]'  # noqa 204
+            /usr/sbin/rabbitmqctl --node {{ name }} set_parameter --vhost={{ '/' if 'vhost' not in p else p.vhost }} {{ p.component }} '{{ param }}' '[{{ p.definition|json }}]'  # noqa 204
                 {%- endif %}
     - runas: rabbitmq
     - onlyif: test -x /usr/sbin/rabbitmqctl

--- a/rabbitmq/package/repo/install.sls
+++ b/rabbitmq/package/repo/install.sls
@@ -20,12 +20,12 @@ rabbitmq-package-repo-pkg-deps:
       - pkgrepo: rabbitmq-package-repo-erlang
       - pkgrepo: rabbitmq-package-repo-rabbitmq
 
-{%- set osfullname = grains['osfullname'] %}
+{%- set osname = grains['os'] %}
 {%- set oscodename = grains['oscodename'] %}
 
 rabbitmq-package-repo-erlang:
   pkgrepo.managed:
-    - name: deb {{ rabbitmq.pkg.repo.erlang.url }}/{{ osfullname|lower }} {{ oscodename }} main
+    - name: deb {{ rabbitmq.pkg.repo.erlang.url }}/{{ osname|lower }} {{ oscodename }} main
     - file: /etc/apt/sources.list.d/erlang.list
     - key_url: {{ rabbitmq.pkg.repo.erlang.key_url }}
     - require_in:
@@ -33,7 +33,7 @@ rabbitmq-package-repo-erlang:
 
 rabbitmq-package-repo-rabbitmq:
   pkgrepo.managed:
-    - name: deb {{ rabbitmq.pkg.repo.rabbitmq.url }}/{{ osfullname|lower }} {{ oscodename }} main
+    - name: deb {{ rabbitmq.pkg.repo.rabbitmq.url }}/{{ osname|lower }} {{ oscodename }} main
     - file: /etc/apt/sources.list.d/rabbitmq.list
     - key_url: {{ rabbitmq.pkg.repo.rabbitmq.key_url }}
     - require_in:


### PR DESCRIPTION
This fixes 2 errors in the CI vms, and probably in regular use too, regarding federation setup : 

first error : 

```
       ----------
                 ID: rabbitmq-config-parameters-present-rabbit-my-federation-upstream-set
           Function: cmd.run
               Name: /usr/sbin/rabbitmqctl --node rabbit set_parameter --vhost=default_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204
             Result: False
            Comment: Command "/usr/sbin/rabbitmqctl --node rabbit set_parameter --vhost=default_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204" run
            Started: 15:54:19.151211
           Duration: 466.897 ms
            Changes:   
              ----------
              pid:
                  7865
              retcode:
                  69
              stderr:
                  warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable
                  Error:
                  Could not parse JSON document: {error,
                                                     {failed_to_decode_json,
                                                         <<"[{\"upstream\": \"my-federation-upstream1\"},]">>}}
              stdout:
                  Setting runtime parameter "my-federation-upstream-set" for component "federation-upstream-set" to "[{"upstream": "my-federation-upstream1"},]" in vhost "default_vhost" ...
```

second error : 

```
       ----------
                 ID: rabbitmq-config-parameters-present-rabbit2-my-federation-upstream-set
           Function: cmd.run
               Name: /usr/sbin/rabbitmqctl --node rabbit2 set_parameter --vhost=rabbit2_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204
             Result: False
            Comment: Command "/usr/sbin/rabbitmqctl --node rabbit2 set_parameter --vhost=rabbit2_vhost federation-upstream-set 'my-federation-upstream-set' '[{"upstream": "my-federation-upstream1"},]'  # noqa 204" run
            Started: 15:54:20.079375
           Duration: 457.14 ms
            Changes:   
              ----------
              pid:
                  7981
              retcode:
                  69
              stderr:
                  warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable
                  Error:
                  Could not parse JSON document: {error,
                                                     {failed_to_decode_json,
                                                         <<"[{\"upstream\": \"my-federation-upstream1\"},]">>}}
              stdout:
                  Setting runtime parameter "my-federation-upstream-set" for component "federation-upstream-set" to "[{"upstream": "my-federation-upstream1"},]" in vhost "rabbit2_vhost" ...
```
